### PR TITLE
feat: Add 'name-tests-test' to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         types_or: [yaml, markdown, html, css, scss, javascript, json]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: name-tests-test
+        args: ["--pytest-test-first"]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 


### PR DESCRIPTION
Motivated by https://github.com/scikit-hep/scikit-hep.github.io/issues/227 and complimentary to PR https://github.com/scikit-hep/scikit-hep.github.io/pull/231.

* Update pre-commit/pre-commit-hooks to v4.3.0
* Add the 'name-tests-test' pre-commit hooks which verifies that test files under `tests/` conform to `pytest` naming conventions.
   - Use the `--pytest-test-first` option to match the `test_.*\.py` naming convention.