### PR TITLE
fix: ruff requirement missing

### DIFF
--- a/src/scikit_hep_repo_review/ratings/ruff.py
+++ b/src/scikit_hep_repo_review/ratings/ruff.py
@@ -50,6 +50,8 @@ class R002(Ruff):
 class R003(Ruff):
     "src directory specified if used"
 
+    requires = {"R001"}
+
     @staticmethod
     def check(pyproject: dict[str, Any], package: Traversable) -> bool | None:
         """


### PR DESCRIPTION
This was missing, causing a fail instead of a skip.
