### PR TITLE
feat: simplify result for json

### DIFF
--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -13,6 +13,11 @@ from markdown_it import MarkdownIt
 
 from .ratings import Rating
 
+__all__ = ["Result", "build", "process", "as_simple_dict"]
+
+def __dir__() -> list[str]:
+    return __all__
+
 # Use module-level entry names
 # repo_review_fixtures = {"pyproject"}
 # repo_review_checks = set(p.__name___ for p in General.__subclasses__())
@@ -107,12 +112,5 @@ def process(package: Traversable) -> dict[str, list[Result]]:
     return results_dict
 
 
-def results_dict_to_json(results_dict: dict[str, list[Result]) -> str:
-    import json
-    from dataclasses import asdict
-
-    new_res = {}
-    for family, result_list in results_dict.items():
-        new_res[family] = [asdict(result) for result in result_list]
-
-    return json.dumps(new_res)
+def as_simple_dict(results_dict: dict[str, list[Result]]) -> str:
+    return {family: dataclasses.asdict(result) for family, results in results_dict.items() for result in results}

--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -114,7 +114,7 @@ def process(package: Traversable) -> dict[str, list[Result]]:
     return results_dict
 
 
-def as_simple_dict(results_dict: dict[str, list[Result]]) -> str:
+def as_simple_dict(results_dict: dict[str, list[Result]]) -> dict[str, dict[str, Any]]:
     return {
         family: dataclasses.asdict(result)
         for family, results in results_dict.items()

--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -107,7 +107,7 @@ def process(package: Traversable) -> dict[str, list[Result]]:
     return results_dict
 
 
-def results_dict_to_json(results_dict: dict) -> str:
+def results_dict_to_json(results_dict: dict[str, list[Result]) -> str:
     import json
     from dataclasses import asdict
 

--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -15,8 +15,10 @@ from .ratings import Rating
 
 __all__ = ["Result", "build", "process", "as_simple_dict"]
 
+
 def __dir__() -> list[str]:
     return __all__
+
 
 # Use module-level entry names
 # repo_review_fixtures = {"pyproject"}
@@ -113,4 +115,8 @@ def process(package: Traversable) -> dict[str, list[Result]]:
 
 
 def as_simple_dict(results_dict: dict[str, list[Result]]) -> str:
-    return {family: dataclasses.asdict(result) for family, results in results_dict.items() for result in results}
+    return {
+        family: dataclasses.asdict(result)
+        for family, results in results_dict.items()
+        for result in results
+    }

--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -105,3 +105,14 @@ def process(package: Traversable) -> dict[str, list[Result]]:
         results_dict[family] = result_list
 
     return results_dict
+
+
+def results_dict_to_json(results_dict: dict) -> str:
+    import json
+    from dataclasses import asdict
+
+    new_res = {}
+    for family, result_list in results_dict.items():
+        new_res[family] = [asdict(result) for result in result_list]
+
+    return json.dumps(new_res)


### PR DESCRIPTION
Feel free to make this consistent with the rest of the package. I ran out of time at the airport. Part 1 of #41 (second part is output formal options).

```python
from scikit_hep_repo_review.processor import process, results_dict_to_json
from pathlib import Path
r = process(Path("."))
s = results_simple_dict(r)

import json
with open("zzz.json", "w") as fout:
    json.dump(s, fout)

with open("zzz.json", "r") as fin:
    dd = json.loads(json.load(fin))
```