### PR TITLE
feat: adding ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package
-        run: python -m pip install .[test]
+        run: python -m pip install .[test,cli]
 
       - name: Test package
-        run: python -m pytest -ra
+        run: PYTHONUTF8=1 python -m pytest -ra
 
   dist:
     name: Distribution build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
         run: python -m pip install .[test,cli]
 
       - name: Test package
-        run: PYTHONUTF8=1 python -m pytest -ra
+        run: python -m pytest -ra
+        env:
+          PYTHONUTF8: "1"
 
   dist:
     name: Distribution build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,14 +53,15 @@ repos:
     rev: v1.3.0
     hooks:
       - id: mypy
-        files: src
+        files: (src|web|tests)
         args: []
         additional_dependencies:
           - click
-          - rich
-          - types-PyYAML
-          - tomli
           - markdown-it-py
+          - pytest
+          - rich
+          - tomli
+          - types-PyYAML
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ def pylint(session: nox.Session) -> None:
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
-    session.install(".[cli]", "pylint")
+    session.install("-e.[cli]", "pylint")
     session.run("pylint", "src", *session.posargs)
 
 
@@ -45,7 +45,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[test]")
+    session.install("-e.[test,cli]")
     session.run("pytest", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ select = [
 extend-ignore = [
   "PLR",    # Design related pylint codes
   "E501",   # Line too long
+  "PT004",  # Incorrect check, usefixtures is the correct way to do this
 ]
 target-version = "py310"
 src = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ version.path = "src/scikit_hep_repo_review/__init__.py"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+addopts = ["-ra", "--strict-markers", "--strict-config"]
 xfail_strict = true
 log_cli_level = "INFO"
 filterwarnings = ["error"]
@@ -82,14 +82,18 @@ testpaths = ["tests"]
 
 
 [tool.mypy]
-files = ["src", "web"]
+files = ["src", "web", "tests"]
 python_version = "3.10"
 warn_unused_configs = true
 strict = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
+disallow_untyped_defs = false
 
+[[tool.mypy.overrides]]
+module = "scikit_hep_repo_review.*"
+disallow_untyped_defs = true
 
 [tool.pylint]
 master.py-version = "3.10"

--- a/src/scikit_hep_repo_review/__main__.py
+++ b/src/scikit_hep_repo_review/__main__.py
@@ -64,8 +64,16 @@ def rich_printer(processed: dict[str, list[Result]], *, output: Path | None) -> 
     type=click.Choice(["rich", "json"]),
     default="rich",
 )
-def main(package: Path, output: Path | None, format: Literal["rich", "json"]) -> None:
-    processed = process(package)
+@click.option(
+    "--ignore",
+    help="Ignore a check or checks, comma separated",
+    default="",
+)
+def main(
+    package: Path, output: Path | None, format: Literal["rich", "json"], ignore: str
+) -> None:
+    ignore_list = [x.strip() for x in ignore.split(",")]
+    processed = process(package, ignore=ignore_list)
 
     if format == "rich":
         rich_printer(processed, output=output)

--- a/src/scikit_hep_repo_review/_compat/tomllib.py
+++ b/src/scikit_hep_repo_review/_compat/tomllib.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info < (3, 11):
+    from tomli import load, loads
+else:
+    from tomllib import load, loads
+
+__all__ = ["load", "loads"]
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/src/scikit_hep_repo_review/fixtures.py
+++ b/src/scikit_hep_repo_review/fixtures.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import functools
+from importlib.abc import Traversable
+from typing import Any
+
+from ._compat import tomllib
+
+
+@functools.cache
+def pyproject(package: Traversable) -> dict[str, Any]:
+    pyproject_path = package.joinpath("pyproject.toml")
+    if pyproject_path.is_file():
+        with pyproject_path.open("rb") as f:
+            return tomllib.load(f)
+    return {}

--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -85,6 +85,17 @@ def is_allowed(ignore_list: set[str], name: str) -> bool:
 def process(
     package: Traversable, *, ignore: Sequence[str] = ()
 ) -> dict[str, list[Result]]:
+    """
+    Process the package and return a dictionary of results.
+
+    Parameters
+    ----------
+    package: Traversable | Path
+        The Path(like) package to process
+
+    ignore: Sequence[str]
+        A list of checks to ignore
+    """
     # Collect all installed plugins
     modules: list[str] = [
         ep.load()

--- a/src/scikit_hep_repo_review/ratings/__init__.py
+++ b/src/scikit_hep_repo_review/ratings/__init__.py
@@ -6,3 +6,6 @@ from typing import ClassVar, Protocol
 class Rating(Protocol):
     family: ClassVar[str]
     requires: ClassVar[set[str]] = set()
+
+    def check(self) -> bool | None:
+        ...

--- a/src/scikit_hep_repo_review/ratings/pyproject.py
+++ b/src/scikit_hep_repo_review/ratings/pyproject.py
@@ -1,24 +1,6 @@
 from __future__ import annotations
 
-import functools
-import sys
-from importlib.abc import Traversable
 from typing import Any
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
-
-
-@functools.cache
-def pyproject(package: Traversable) -> dict[str, Any]:
-    pyproject_path = package.joinpath("pyproject.toml")
-    if pyproject_path.is_file():
-        with pyproject_path.open("rb") as f:
-            return tomllib.load(f)
-    return {}
-
 
 # PP: PyProject.toml
 ## PP0xx: Build system
@@ -192,5 +174,5 @@ class PP309(PyProject):
         return "filterwarnings" in options
 
 
-repo_review_fixtures = {"pyproject"}
+repo_review_fixtures = set[str]()
 repo_review_checks = {p.__name__ for p in PyProject.__subclasses__()}

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,51 @@
+import importlib.metadata
+import sys
+from importlib.abc import Traversable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from scikit_hep_repo_review.processor import process
+
+
+class D1:
+    "Was passed correctly"
+    family = "pyproject"
+
+    @staticmethod
+    def check(package: Traversable) -> bool:
+        """
+        Requires Path(".") to be passed
+        """
+
+        return package == Path(".")
+
+
+def test_no_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group: []  # noqa: ARG005
+    )
+
+    results = process(Path("."))
+    assert not results["general"]
+    assert not results["pyproject"]
+    assert len(results) == 2
+
+
+def test_custom_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    mod = importlib.metadata.EntryPoint(name="x", group="y", value="test_module")
+    sys.modules["test_module"] = ModuleType("test_module")
+    sys.modules["test_module"].D1 = D1  # type: ignore[attr-defined]
+    sys.modules["test_module"].repo_review_checks = {"D1"}  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group: [mod]  # noqa: ARG005
+    )
+
+    results = process(Path("."))
+
+    assert not results["general"]
+    assert len(results["pyproject"]) == 1
+    assert results["pyproject"][0].name == "D1"
+    assert results["pyproject"][0].result
+    assert len(results) == 2

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -9,7 +9,7 @@ import pytest
 from scikit_hep_repo_review.processor import process
 
 
-class D1:
+class D100:
     "Was passed correctly"
     family = "pyproject"
 
@@ -20,6 +20,19 @@ class D1:
         """
 
         return package == Path(".")
+
+
+class D200:
+    "Always true"
+    family = "pyproject"
+
+    @staticmethod
+    def check() -> bool:
+        """
+        Can't be false.
+        """
+
+        return True
 
 
 def test_no_checks(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -33,19 +46,46 @@ def test_no_checks(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(results) == 2
 
 
-def test_custom_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture()
+def load_test_module(monkeypatch: pytest.MonkeyPatch) -> None:
     mod = importlib.metadata.EntryPoint(name="x", group="y", value="test_module")
     sys.modules["test_module"] = ModuleType("test_module")
-    sys.modules["test_module"].D1 = D1  # type: ignore[attr-defined]
-    sys.modules["test_module"].repo_review_checks = {"D1"}  # type: ignore[attr-defined]
+    sys.modules["test_module"].D100 = D100  # type: ignore[attr-defined]
+    sys.modules["test_module"].D200 = D200  # type: ignore[attr-defined]
+    sys.modules["test_module"].repo_review_checks = {"D100", "D200"}  # type: ignore[attr-defined]
     monkeypatch.setattr(
         importlib.metadata, "entry_points", lambda group: [mod]  # noqa: ARG005
     )
 
+
+@pytest.mark.usefixtures("load_test_module")
+def test_custom_checks() -> None:
     results = process(Path("."))
 
     assert not results["general"]
-    assert len(results["pyproject"]) == 1
-    assert results["pyproject"][0].name == "D1"
+    assert len(results["pyproject"]) == 2
+    assert results["pyproject"][0].name == "D100"
     assert results["pyproject"][0].result
+    assert results["pyproject"][1].name == "D200"
+    assert results["pyproject"][1].result
+    assert len(results) == 2
+
+
+@pytest.mark.usefixtures("load_test_module")
+def test_ignore_filter_single() -> None:
+    results = process(Path("."), ignore=["D100"])
+
+    assert not results["general"]
+    assert len(results["pyproject"]) == 1
+    assert results["pyproject"][0].name == "D200"
+    assert results["pyproject"][0].result
+    assert len(results) == 2
+
+
+@pytest.mark.usefixtures("load_test_module")
+def test_ignore_filter_letter() -> None:
+    results = process(Path("."), ignore=["D"])
+
+    assert not results["general"]
+    assert len(results["pyproject"]) == 0
     assert len(results) == 2

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,0 +1,13 @@
+import subprocess
+
+import pytest
+
+pytest.importorskip("rich")
+
+
+def test_cmd_help():
+    subprocess.run(["scikit-hep-repo-review", "--help"], check=True)
+
+
+def test_cmd_basic():
+    subprocess.run(["scikit-hep-repo-review", "."], check=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 import scikit_hep_repo_review as m
 from scikit_hep_repo_review.ghpath import GHPath
 from scikit_hep_repo_review.processor import process

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -13,6 +13,7 @@ def test_version():
     assert m.__version__
 
 
+@pytest.mark.skip(reason="Can be rate limited")
 def test_pyodide():
     package = GHPath(repo="scikit-hep/repo-review", branch="main")
     results = process(package)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -23,6 +23,6 @@ def test_pyodide():
 
 
 def test_local():
-    package = GHPath(repo="scikit-hep/repo-review", branch="main")
+    package = DIR.parent
     results = process(package)
     assert results

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 import scikit_hep_repo_review as m
 from scikit_hep_repo_review.ghpath import GHPath
 from scikit_hep_repo_review.processor import process
@@ -15,8 +13,13 @@ def test_version():
     assert m.__version__
 
 
-@pytest.mark.skip()
 def test_pyodide():
+    package = GHPath(repo="scikit-hep/repo-review", branch="main")
+    results = process(package)
+    assert results
+
+
+def test_local():
     package = GHPath(repo="scikit-hep/repo-review", branch="main")
     results = process(package)
     assert results


### PR DESCRIPTION
Starting ignores and adding a bit of testing and refactoring. Will close #40.

Other changes:
* Pulling out the pyproject fixture into built in fixtures (similar to the package fixture). (Preparation for the upcoming split)
* Some typing updates

Currently this supports ignoring the string code or the entire code.

Planned (later PR): fixtures need entry point. Family as attribute (sorted). Maybe some way to sort families. Check/rating unify language.