### PR TITLE
refactor: rework families

### DIFF
--- a/src/scikit_hep_repo_review/__main__.py
+++ b/src/scikit_hep_repo_review/__main__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import json
 from pathlib import Path
 from typing import Literal
@@ -21,10 +22,10 @@ rich.traceback.install(suppress=[click, rich], show_locals=True, width=None)
 # repo_review_checks = set(p.__name___ for p in General.__subclasses__())
 
 
-def rich_printer(processed: dict[str, list[Result]], *, output: Path | None) -> None:
+def rich_printer(processed: list[Result], *, output: Path | None) -> None:
     console = rich.console.Console(record=True)
 
-    for family, results_list in processed.items():
+    for family, results_list in itertools.groupby(processed, lambda r: r.family):
         tree = rich.tree.Tree(f"[bold]{family}[/bold]:")
         for result in results_list:
             msg = rich.text.Text()

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -41,9 +41,7 @@ def test_no_checks(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     results = scikit_hep_repo_review.processor.process(Path("."))
-    assert not results["general"]
-    assert not results["pyproject"]
-    assert len(results) == 2
+    assert len(results) == 0
 
 
 def test_load_entry_point(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -69,12 +67,11 @@ def test_custom_checks(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     results = scikit_hep_repo_review.processor.process(Path("."))
 
-    assert not results["general"]
-    assert len(results["pyproject"]) == 2
-    assert results["pyproject"][0].name == "D100"
-    assert results["pyproject"][0].result
-    assert results["pyproject"][1].name == "D200"
-    assert results["pyproject"][1].result
+    assert len(results) == 2
+    assert results[0].name == "D100"
+    assert results[0].result
+    assert results[1].name == "D200"
+    assert results[1].result
     assert len(results) == 2
 
 
@@ -86,11 +83,9 @@ def test_ignore_filter_single(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     results = scikit_hep_repo_review.processor.process(Path("."), ignore=["D100"])
 
-    assert not results["general"]
-    assert len(results["pyproject"]) == 1
-    assert results["pyproject"][0].name == "D200"
-    assert results["pyproject"][0].result
-    assert len(results) == 2
+    assert len(results) == 1
+    assert results[0].name == "D200"
+    assert results[0].result
 
 
 def test_ignore_filter_letter(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -101,6 +96,4 @@ def test_ignore_filter_letter(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     results = scikit_hep_repo_review.processor.process(Path("."), ignore=["D"])
 
-    assert not results["general"]
-    assert len(results["pyproject"]) == 0
-    assert len(results) == 2
+    assert not results


### PR DESCRIPTION
Reworking families, using sort by and groupby instead of nested dicts. Makes the code and return (especially in JSON) simpler.

Still need a way to attach sorting weights and name/descriptions to families.
