### PR TITLE
feat: topological graph for fixtures, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ examples of repositories that at least partially follow the guidelines include
 ### Development
 
 This repository is intended to be fun to develop - it requires and uses Python
-3.10, and makes a few potentially... uncommon decisions. You might not want to
-design your library this way, but this is not a library. It's a fun and
-enjoyable app.
+3.10, and uses a lot of the new features in 3.9 and 3.10. It's maybe not
+entirely conventional, but it's fun.
 
 There are a few key designs that are very useful and make this possible. First,
 all paths are handled as Traversables. This allows a simple Traversable
@@ -50,9 +49,11 @@ webapp. It also would allow `zipfile.Path` to work just as well, too - no need
 to extract.
 
 Checks can request fixtures (like pytest) as arguments. Check files can add new
-fixtures as needed. Fixtures are are specified with entry points, and take a
-single `package` argument (which is also a built-in fixture). Checks are
-specified via an entrypoint that returns a dict of checks.
+fixtures as needed. Fixtures are are specified with entry points, and take any
+other fixture as arguments as well - the `package` fixture represents the root
+of the package you are checking, and is the basis for all other fixtures.
+Checks are specified via an entrypoint that returns a dict of checks; this also
+can accept fixtures, allowing dynamic check listings.
 
 Check files do not depend on the main library, and can be extended (similar to
 Flake8). You register new check files via entry-points - so extending this is
@@ -66,7 +67,8 @@ have a check classmethod. The docstring of this method is the failure message,
 and supports substitution. Arguments to this method are fixtures, and `package`
 is the built-in one providing the package directory as a Traversable. Any other
 fixtures are available by name. A new fixture is given the package Traversable,
-and can produce anything (recommended to be cached via `functools.cache`).
+and can produce anything; fixtures are topologically sorted, pre-computed and
+cached.
 
 The runner will topologically sort the checks, and checks that do not run will
 get a `None` result and the check classmethod will not run. The front-end (Rich

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ github = "scikit_hep_repo_review.checks.github:repo_review_checks"
 
 [project.entry-points."scikit_hep_repo_review.fixtures"]
 pyproject = "scikit_hep_repo_review.fixtures:pyproject"
+package = "scikit_hep_repo_review.fixtures:package"
 workflows = "scikit_hep_repo_review.checks.github:workflows"
 dependabot = "scikit_hep_repo_review.checks.github:dependabot"
 precommit = "scikit_hep_repo_review.checks.precommit:precommit"

--- a/src/scikit_hep_repo_review/checks/github.py
+++ b/src/scikit_hep_repo_review/checks/github.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import functools
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +11,6 @@ import yaml
 from .._compat.importlib.resources.abc import Traversable
 
 
-@functools.cache
 def workflows(package: Traversable) -> dict[str, Any]:
     workflows_base_path = package.joinpath(".github/workflows")
     workflows_dict: dict[str, Any] = {}
@@ -25,7 +23,6 @@ def workflows(package: Traversable) -> dict[str, Any]:
     return workflows_dict
 
 
-@functools.cache
 def dependabot(package: Traversable) -> dict[str, Any]:
     dependabot_path = package.joinpath(".github/dependabot.yml")
     if dependabot_path.is_file():

--- a/src/scikit_hep_repo_review/checks/precommit.py
+++ b/src/scikit_hep_repo_review/checks/precommit.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Any, ClassVar, Protocol
 
 import yaml
@@ -11,7 +10,6 @@ import yaml
 from .._compat.importlib.resources.abc import Traversable
 
 
-@functools.cache
 def precommit(package: Traversable) -> dict[str, Any]:
     precommit_path = package.joinpath(".pre-commit-config.yaml")
     if precommit_path.is_file():

--- a/src/scikit_hep_repo_review/fixtures.py
+++ b/src/scikit_hep_repo_review/fixtures.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
-import functools
 from typing import Any
 
 from ._compat import tomllib
 from ._compat.importlib.resources.abc import Traversable
 
+__all__ = ["pyproject", "package"]
 
-@functools.cache
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 def pyproject(package: Traversable) -> dict[str, Any]:
     pyproject_path = package.joinpath("pyproject.toml")
     if pyproject_path.is_file():
         with pyproject_path.open("rb") as f:
             return tomllib.load(f)
     return {}
+
+
+def package(package: Traversable) -> Traversable:
+    return package

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -51,7 +51,7 @@ def test_load_entry_point(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         importlib.metadata, "entry_points", lambda group: [ep]  # noqa: ARG005
     )
-    checks = scikit_hep_repo_review.processor.collect_checks()
+    checks = scikit_hep_repo_review.processor.collect_checks({"package": Path(".")})
 
     assert len(checks) == 2
     assert "D100" in checks
@@ -63,7 +63,7 @@ def test_custom_checks(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         scikit_hep_repo_review.processor,
         "collect_checks",
-        lambda: {"D100": D100, "D200": D200},
+        lambda _: {"D100": D100, "D200": D200},
     )
     results = scikit_hep_repo_review.processor.process(Path("."))
 
@@ -79,7 +79,7 @@ def test_ignore_filter_single(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         scikit_hep_repo_review.processor,
         "collect_checks",
-        lambda: {"D100": D100, "D200": D200},
+        lambda _: {"D100": D100, "D200": D200},
     )
     results = scikit_hep_repo_review.processor.process(Path("."), ignore=["D100"])
 
@@ -92,7 +92,7 @@ def test_ignore_filter_letter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         scikit_hep_repo_review.processor,
         "collect_checks",
-        lambda: {"D100": D100, "D200": D200},
+        lambda _: {"D100": D100, "D200": D200},
     )
     results = scikit_hep_repo_review.processor.process(Path("."), ignore=["D"])
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,95 @@
+import importlib.metadata
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from scikit_hep_repo_review._compat.importlib.resources.abc import Traversable
+from scikit_hep_repo_review.fixtures import package
+from scikit_hep_repo_review.processor import (
+    apply_fixtures,
+    collect_checks,
+    compute_fixtures,
+)
+
+
+class D100:
+    "Was passed correctly"
+    family = "pyproject"
+
+    @staticmethod
+    def check(package: Traversable) -> bool:
+        """
+        Requires Path(".") to be passed
+        """
+
+        return package == Path(".")
+
+
+class D200:
+    "Always true"
+    family = "pyproject"
+
+    @staticmethod
+    def check() -> bool:
+        """
+        Can't be false.
+        """
+
+        return True
+
+
+def nothing() -> int:
+    return 42
+
+
+def simple(package: Traversable) -> str:
+    return str(package)
+
+
+def not_simple(simple: str, package: Traversable) -> str:
+    return f"{simple} {package}"
+
+
+def get_checks(some_bool: bool) -> dict[str, type]:
+    return {"D100": D100, "D200": D200} if some_bool else {"D100": D100}
+
+
+def test_process_fixtures() -> None:
+    fixtures = compute_fixtures(
+        Path("."), {"simple": simple, "nothing": nothing, "not_simple": not_simple}
+    )
+
+    assert apply_fixtures(fixtures, nothing) == 42
+    assert apply_fixtures(fixtures, simple) == "."
+    assert apply_fixtures(fixtures, not_simple) == ". ."
+
+
+def test_process_fixtures_with_package() -> None:
+    fixtures = compute_fixtures(
+        Path("."),
+        {
+            "simple": simple,
+            "nothing": nothing,
+            "not_simple": not_simple,
+            "package": package,
+        },
+    )
+
+    assert apply_fixtures(fixtures, nothing) == 42
+    assert apply_fixtures(fixtures, simple) == "."
+    assert apply_fixtures(fixtures, package) == Path(".")
+    assert apply_fixtures(fixtures, not_simple) == ". ."
+
+
+@pytest.mark.parametrize("some_bool", [True, False])
+def test_process_checks(monkeypatch: pytest.MonkeyPatch, some_bool: bool) -> None:
+    ep = importlib.metadata.EntryPoint(name="x", group="y", value="test_module:f")
+    sys.modules["test_module"] = ModuleType("test_module")
+    sys.modules["test_module"].f = get_checks  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group: [ep]  # noqa: ARG005
+    )
+    checks = collect_checks({"package": Path("."), "some_bool": some_bool})
+    assert len(checks) == 1 + some_bool


### PR DESCRIPTION
By applying the topological sort to fixtures, they now can depend on each other (like pytest); while this is nice for consistently, the main new feature comes when computing the check getter functions, which now accept fixtures. This means checks can be dynamic based on the project (such as having different sets of checks for different build backends). This also now caches the fixture output automatically, removing the need for the functools caching. One downside is that modifying the return value of a fixture is UB, but with the cache, it probably was before too.

I'm very happy with the new system. It adds the feature I wanted while simplifying and increasing consistency.
