### PR TITLE
refactor: checks as objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ and can produce anything; fixtures are topologically sorted, pre-computed and
 cached.
 
 The runner will topologically sort the checks, and checks that do not run will
-get a `None` result and the check classmethod will not run. The front-end (Rich
+get a `None` result and the check method will not run. The front-end (Rich
 powered CLI or Pyodide webapp) will render the markdown-formatted check
 docstring only if the result is `False`.
 

--- a/src/scikit_hep_repo_review/checks/__init__.py
+++ b/src/scikit_hep_repo_review/checks/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Set
 from typing import ClassVar, Protocol
 
 
 class Check(Protocol):
     family: ClassVar[str]
-    requires: ClassVar[set[str]] = set()
+    requires: ClassVar[Set[str]] = frozenset()
 
     def check(self) -> bool | None:
         ...

--- a/src/scikit_hep_repo_review/checks/general.py
+++ b/src/scikit_hep_repo_review/checks/general.py
@@ -84,5 +84,5 @@ class PY007(General):
         )
 
 
-def repo_review_checks() -> dict[str, type[General]]:
-    return {p.__name__: p for p in General.__subclasses__()}
+def repo_review_checks() -> dict[str, General]:
+    return {p.__name__: p() for p in General.__subclasses__()}

--- a/src/scikit_hep_repo_review/checks/github.py
+++ b/src/scikit_hep_repo_review/checks/github.py
@@ -165,5 +165,5 @@ class GH211(GitHub):
         return True
 
 
-def repo_review_checks() -> dict[str, type[GitHub]]:
-    return {p.__name__: p for p in GitHub.__subclasses__()}
+def repo_review_checks() -> dict[str, GitHub]:
+    return {p.__name__: p() for p in GitHub.__subclasses__()}

--- a/src/scikit_hep_repo_review/checks/mypy.py
+++ b/src/scikit_hep_repo_review/checks/mypy.py
@@ -146,5 +146,5 @@ class PP206(MyPy):
                 return False
 
 
-def repo_review_checks() -> dict[str, type[MyPy]]:
-    return {p.__name__: p for p in MyPy.__subclasses__()}
+def repo_review_checks() -> dict[str, MyPy]:
+    return {p.__name__: p() for p in MyPy.__subclasses__()}

--- a/src/scikit_hep_repo_review/checks/precommit.py
+++ b/src/scikit_hep_repo_review/checks/precommit.py
@@ -124,5 +124,5 @@ class PC901(PreCommit):
         return "autoupdate_commit_msg" in precommit.get("ci", {})
 
 
-def repo_review_checks() -> dict[str, type[PreCommit]]:
-    return {p.__name__: p for p in PreCommit.__subclasses__()}
+def repo_review_checks() -> dict[str, PreCommit]:
+    return {p.__name__: p() for p in PreCommit.__subclasses__()}

--- a/src/scikit_hep_repo_review/checks/pyproject.py
+++ b/src/scikit_hep_repo_review/checks/pyproject.py
@@ -174,5 +174,5 @@ class PP309(PyProject):
         return "filterwarnings" in options
 
 
-def repo_review_checks() -> dict[str, type[PyProject]]:
-    return {p.__name__: p for p in PyProject.__subclasses__()}
+def repo_review_checks() -> dict[str, PyProject]:
+    return {p.__name__: p() for p in PyProject.__subclasses__()}

--- a/src/scikit_hep_repo_review/checks/ruff.py
+++ b/src/scikit_hep_repo_review/checks/ruff.py
@@ -116,8 +116,8 @@ class R103(R1xx):
     name = "pyupgrade"
 
 
-def repo_review_checks() -> dict[str, type[Ruff]]:
+def repo_review_checks() -> dict[str, Ruff]:
     base_classes = set(Ruff.__subclasses__()) - {R1xx}
     r1xx_classes = set(R1xx.__subclasses__())
     repo_review_checks = base_classes | r1xx_classes
-    return {p.__name__: p for p in repo_review_checks}
+    return {p.__name__: p() for p in repo_review_checks}

--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -98,7 +98,7 @@ def collect_fixtures() -> dict[str, Callable[[Traversable], Any]]:
     }
 
 
-def collect_checks(fixtures: Mapping[str, Any]) -> dict[str, type[Check]]:
+def collect_checks(fixtures: Mapping[str, Any]) -> dict[str, Check]:
     check_functions = (
         ep.load()
         for ep in importlib.metadata.entry_points(group="scikit_hep_repo_review.checks")
@@ -134,7 +134,7 @@ def process(package: Traversable, *, ignore: Sequence[str] = ()) -> list[Result]
     config = pyproject(package).get("tool", {}).get("repo-review", {})
     skip_checks = set(ignore) | set(config.get("ignore", ()))
 
-    tasks: dict[str, type[Check]] = {
+    tasks: dict[str, Check] = {
         n: r for n, r in checks.items() if is_allowed(skip_checks, n)
     }
     graph: dict[str, set[str]] = {


### PR DESCRIPTION
This makes the checks normal objects. The collection function can therefore configure them as normal objects if needed.

