### PR TITLE
fix: strip paragraph tags when converting to markdown

### DIFF
--- a/src/scikit_hep_repo_review/processor.py
+++ b/src/scikit_hep_repo_review/processor.py
@@ -40,8 +40,8 @@ class Result:
     err_msg: str = ""
 
     def err_markdown(self) -> str:
-        result: str = md.render(self.err_msg)
-        return result
+        result: str = md.render(self.err_msg).strip()
+        return result.removeprefix("<p>").removesuffix("</p>").strip()
 
 
 class ProcessReturn(typing.NamedTuple):


### PR DESCRIPTION
Produces much nicer output.
